### PR TITLE
now it is possible to define sql as a transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,10 @@
 
 # other stuff
 .idea
-/*/target/
+*/target/*
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# ignore target folders
-*/target/*
+

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -14,6 +14,7 @@
     </parent>
 
     <dependencies>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -23,10 +24,16 @@
             <artifactId>spark-sql_${scala.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-java8-compat_${scala.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/pipelines/src/main/java/dataengine/pipelines/DataBiTransformation.java
+++ b/pipelines/src/main/java/dataengine/pipelines/DataBiTransformation.java
@@ -1,8 +1,21 @@
 package dataengine.pipelines;
 
+import dataengine.pipelines.sql.SparkSqlUnresolvedRelationResolver;
+import dataengine.pipelines.transformations.Transformation;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 
+import javax.annotation.Nonnull;
 import java.util.function.BiFunction;
 
-public interface DataBiTransformation<S1, S2, D> extends BiFunction<Dataset<S1>, Dataset<S2>, Dataset<D>> {
+public interface DataBiTransformation<S1, S2, D> {
+
+    Dataset<D> apply(Dataset<S1> s1Dataset, Dataset<S2> s2Dataset);
+
+    default <D2> DataBiTransformation<S1, S2, D2> andThenEncode(Encoder<D2> encoder) {
+        return (s1, s2) -> Transformation.<D, D2>encode(encoder).apply(apply(s1, s2));
+    }
+
 }

--- a/pipelines/src/main/java/dataengine/pipelines/DataPipe.java
+++ b/pipelines/src/main/java/dataengine/pipelines/DataPipe.java
@@ -1,38 +1,67 @@
 package dataengine.pipelines;
 
+import dataengine.pipelines.transformations.Transformation;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
+import java.util.List;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DataPipe<T> {
 
     @Nonnull
-    Dataset<T> dataset;
+    private final Dataset<T> dataset;
 
     public static <T> DataPipe<T> read(DataSource<T> source) {
         return new DataPipe<>(source.get());
+    }
+
+    public void write(DataSink<T> destination) {
+        destination.accept(dataset);
     }
 
     public <D> DataPipe<D> transformation(DataTransformation<T, D> mapper) {
         return new DataPipe<>(mapper.apply(dataset));
     }
 
-    public <T2, D> DataPipe<D> merge(DataPipe<T2> otherDataPipe, DataBiTransformation<T, T2, D> merger) {
+    public <D> DataPipe<D> encode(Encoder<D> encoder) {
+        return transformation(Transformation.encode(encoder));
+    }
+
+    public <T2, D> DataPipe<D> mergeWith(DataPipe<T2> otherDataPipe, DataBiTransformation<T, T2, D> merger) {
         Dataset<D> mergedDataset = merger.apply(dataset, otherDataPipe.dataset);
         return new DataPipe<>(mergedDataset);
     }
 
-    public DataPipe<T> reduce(DataBiTransformation<T, T, T> reducer, Collection<DataPipe<T>> otherDataPipes) {
+    public DataPipe<T> reduce(List<DataPipe<T>> otherDataPipes, DataBiTransformation<T, T, T> reducer) {
         Dataset<T> reducedDataset = otherDataPipes.stream().map(o -> o.dataset).reduce(dataset, reducer::apply);
         return new DataPipe<>(reducedDataset);
     }
 
-    public void write(DataSink<T> destination) {
-        destination.accept(dataset);
+    public static <S1, S2, D> DataPipe<D> mergeAll(
+            DataPipe<S1> pipe1, DataPipe<S2> pipe2,
+            DataBiTransformation<S1, S2, D> merger) {
+        return pipe1.mergeWith(pipe2, merger);
+    }
+
+    public static interface Data3Transformation<S1, S2, S3, D> {
+
+        Dataset<D> apply(Dataset<S1> s1Dataset, Dataset<S2> s2Dataset, Dataset<S3> s3Dataset);
+
+        default <D2> Data3Transformation<S1, S2, S3, D2> andThenEncode(Encoder<D2> encoder) {
+            return (s1, s2, s3) -> Transformation.<D, D2>encode(encoder).apply(apply(s1, s2, s3));
+        }
+
+    }
+
+    public static <S1, S2, S3, D> DataPipe<D> mergeAll(
+            DataPipe<S1> pipe1, DataPipe<S2> pipe2, DataPipe<S3> pipe3,
+            Data3Transformation<S1, S2, S3, D> merger) {
+        Dataset<D> mergedDataset = merger.apply(pipe1.dataset, pipe2.dataset, pipe3.dataset);
+        return new DataPipe<>(mergedDataset);
     }
 
 }

--- a/pipelines/src/main/java/dataengine/pipelines/DataTransformation.java
+++ b/pipelines/src/main/java/dataengine/pipelines/DataTransformation.java
@@ -1,8 +1,17 @@
 package dataengine.pipelines;
 
+import dataengine.pipelines.transformations.Transformation;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
 
 import java.util.function.Function;
 
-public interface DataTransformation<S, D> extends Function<Dataset<S>, Dataset<D>> {
+public interface DataTransformation<S, D> {
+
+    Dataset<D> apply(Dataset<S> sDataset);
+
+    default <D2> DataTransformation<S, D2> andThenEncode(Encoder<D2> encoder) {
+        return s -> Transformation.<D, D2>encode(encoder).apply(apply(s));
+    }
+
 }

--- a/pipelines/src/main/java/dataengine/pipelines/sql/SparkSqlUnresolvedRelationResolver.java
+++ b/pipelines/src/main/java/dataengine/pipelines/sql/SparkSqlUnresolvedRelationResolver.java
@@ -1,0 +1,55 @@
+package dataengine.pipelines.sql;
+
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import scala.compat.java8.functionConverterImpls.FromJavaFunction;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.function.Function;
+
+@Value
+@Builder
+public class SparkSqlUnresolvedRelationResolver {
+
+    @Singular
+    @Nonnull
+    Map<String, LogicalPlan> plans;
+
+    public class UnresolvedRelationResolver implements Function<LogicalPlan, LogicalPlan> {
+
+        @Override
+        public LogicalPlan apply(LogicalPlan logicalPlan) {
+            if (!(logicalPlan instanceof UnresolvedRelation))
+                return logicalPlan.mapChildren(new FromJavaFunction<>(this));
+            LogicalPlan resolvedRelation = plans.get(((UnresolvedRelation) logicalPlan).tableName());
+            if (resolvedRelation == null)
+                return logicalPlan.mapChildren(new FromJavaFunction<>(this));
+            return resolvedRelation;
+        }
+
+    }
+
+    public LogicalPlan resolve(SparkSession sparkSession, String sql) {
+        LogicalPlan logicalPlanWithUnresolvedRelations = null;
+        try {
+            logicalPlanWithUnresolvedRelations = sparkSession.sessionState().sqlParser().parsePlan(sql);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("bad sql", e);
+        }
+        return logicalPlanWithUnresolvedRelations.mapChildren(new FromJavaFunction<>(new UnresolvedRelationResolver()));
+    }
+
+    public Dataset<Row> resolveAsDataset(SparkSession sparkSession, String sql) {
+        return Dataset.ofRows(sparkSession, resolve(sparkSession, sql));
+    }
+
+}

--- a/pipelines/src/main/java/dataengine/pipelines/transformations/Transformation.java
+++ b/pipelines/src/main/java/dataengine/pipelines/transformations/Transformation.java
@@ -1,0 +1,62 @@
+package dataengine.pipelines.transformations;
+
+import dataengine.pipelines.DataBiTransformation;
+import dataengine.pipelines.DataPipe;
+import dataengine.pipelines.DataTransformation;
+import dataengine.pipelines.sql.SparkSqlUnresolvedRelationResolver;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.annotation.Nonnull;
+
+public class Transformation {
+
+    public static <S, D> DataTransformation<S, D> map(MapFunction<S, D> map, Encoder<D> encoder) {
+        return s -> s.map(map, encoder);
+    }
+
+    public static <S, D> DataTransformation<S, D> flatMap(FlatMapFunction<S, D> map, Encoder<D> encoder) {
+        return s -> s.flatMap(map, encoder);
+    }
+
+    public static <S, D> DataTransformation<S, D> encode(Encoder<D> encoder) {
+        return s -> s.as(encoder);
+    }
+
+    public static <S> DataTransformation<S, Row> sql(@Nonnull String sourceName, @Nonnull String sql) {
+        return s -> {
+            SparkSqlUnresolvedRelationResolver resolver = SparkSqlUnresolvedRelationResolver.builder().plan(sourceName, s.logicalPlan()).build();
+            return resolver.resolveAsDataset(s.sparkSession(), sql);
+        };
+    }
+
+    public static <S1, S2> DataBiTransformation<S1, S2, Row> sqlMerge(@Nonnull String sourceName1,
+                                                                      @Nonnull String sourceName2,
+                                                                      @Nonnull String sql) {
+        return (s1, s2) -> {
+            SparkSqlUnresolvedRelationResolver resolver = SparkSqlUnresolvedRelationResolver.builder()
+                    .plan(sourceName1, s1.logicalPlan())
+                    .plan(sourceName2, s2.logicalPlan())
+                    .build();
+            return resolver.resolveAsDataset(SparkSession.active(), sql);
+        };
+    }
+
+    public static <S1, S2, S3> DataPipe.Data3Transformation<S1, S2, S3, Row> sqlMerge(@Nonnull String sourceName1,
+                                                                                      @Nonnull String sourceName2,
+                                                                                      @Nonnull String sourceName3,
+                                                                                      @Nonnull String sql) {
+        return (s1, s2, s3) -> {
+            SparkSqlUnresolvedRelationResolver resolver = SparkSqlUnresolvedRelationResolver.builder()
+                    .plan(sourceName1, s1.logicalPlan())
+                    .plan(sourceName2, s2.logicalPlan())
+                    .plan(sourceName3, s3.logicalPlan())
+                    .build();
+            return resolver.resolveAsDataset(SparkSession.active(), sql);
+        };
+    }
+
+}

--- a/pipelines/src/test/java/dataengine/pipelines/DataPipeTest.java
+++ b/pipelines/src/test/java/dataengine/pipelines/DataPipeTest.java
@@ -1,42 +1,27 @@
 package dataengine.pipelines;
 
-import org.apache.spark.api.java.function.MapFunction;
-import org.apache.spark.sql.Dataset;
+import dataengine.pipelines.transformations.Transformation;
 import org.apache.spark.sql.Encoders;
-import org.apache.spark.sql.SparkSession;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-class DataPipeTest {
+class DataPipeTest extends SparkSessionTest {
 
-    static SparkSession sparkSession;
-
-    @BeforeAll
-    static void init() {
-        sparkSession = SparkSession.builder().master("local").getOrCreate();
-    }
-
-    @AfterAll
-    static void close() {
-        sparkSession.close();
-    }
-
-    @org.junit.jupiter.api.Test
+    @Test
     void readAndWritePipeline() {
         List<String> data = new LinkedList<>();
 
         DataSource<String> dataSource = () -> sparkSession.createDataset(Arrays.asList("a", "aa", "aaa"), Encoders.STRING());
         DataSink<String> dataSink = d -> data.addAll(d.collectAsList());
 
+        DataTransformation<String, String> tx = Transformation.map(s -> s + s.length(), Encoders.STRING());
 
         DataPipe.read(dataSource)
-                .transformation(s -> s.map((MapFunction<String, String>) ss -> ss + ss.length(), Encoders.STRING()))
+                .transformation(tx)
                 .write(dataSink);
 
         Assertions.assertEquals(Arrays.asList("a1", "aa2", "aaa3"), data);

--- a/pipelines/src/test/java/dataengine/pipelines/SparkSessionTest.java
+++ b/pipelines/src/test/java/dataengine/pipelines/SparkSessionTest.java
@@ -1,0 +1,21 @@
+package dataengine.pipelines;
+
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class SparkSessionTest {
+
+    protected static SparkSession sparkSession;
+
+    @BeforeAll
+    static void init() {
+        sparkSession = SparkSession.builder().master("local").getOrCreate();
+    }
+
+    @AfterAll
+    static void close() {
+        sparkSession.close();
+    }
+
+}

--- a/pipelines/src/test/java/dataengine/pipelines/sql/SparkSqlUnresolvedRelationResolverTest.java
+++ b/pipelines/src/test/java/dataengine/pipelines/sql/SparkSqlUnresolvedRelationResolverTest.java
@@ -1,0 +1,50 @@
+package dataengine.pipelines.sql;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class SparkSqlUnresolvedRelationResolverTest {
+
+    public static final String SQL_SOURCE = "select 100 as value";
+    public static final String SQL_UNRESOLVED = "select value+1 as valueWithOperation from table";
+    public static final String SQL_TABLE = "table";
+
+    static SparkSession sparkSession;
+
+    @BeforeAll
+    static void init() {
+        sparkSession = SparkSession.builder().master("local").getOrCreate();
+    }
+
+    @AfterAll
+    static void close() {
+        sparkSession.close();
+    }
+
+    @Test
+    public void testSqlResolver() throws ParseException {
+        // given
+        LogicalPlan logicalPlanWithData = sparkSession.sessionState().sqlParser().parsePlan(SQL_SOURCE);
+        SparkSqlUnresolvedRelationResolver resolver = SparkSqlUnresolvedRelationResolver.builder().plan(SQL_TABLE, logicalPlanWithData).build();
+
+        // when
+        Dataset<Row> datasetResolved = resolver.resolveAsDataset(sparkSession, SQL_UNRESOLVED);
+
+        // then
+        List<Integer> list = datasetResolved.select("valueWithOperation").as(Encoders.INT()).collectAsList();
+        Assertions.assertEquals(Collections.singletonList(101), list);
+    }
+
+}

--- a/pipelines/src/test/java/dataengine/pipelines/transformations/TransformationTest.java
+++ b/pipelines/src/test/java/dataengine/pipelines/transformations/TransformationTest.java
@@ -1,0 +1,73 @@
+package dataengine.pipelines.transformations;
+
+import dataengine.pipelines.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class TransformationTest extends SparkSessionTest {
+
+    @Test
+    void testSql() {
+
+        List<Integer> data = new LinkedList<>();
+
+        DataSource<Integer> dataSource = () -> sparkSession.createDataset(Arrays.asList(1, 2, 3, 4, 5, 6), Encoders.INT());
+        DataSink<BigDecimal> dataSink = d -> data.addAll(d.collectAsList().stream().map(BigDecimal::intValue).collect(Collectors.toList()));
+
+        DataTransformation<Integer, Row> tx1 = Transformation.sql("source", "select value*2 as value from source");
+        DataTransformation<Row, Row> tx2 = Transformation.sql("source2", "select sum(value) as sumValue from source2");
+
+        DataPipe.read(dataSource)
+                .transformation(tx1)
+                .transformation(tx2)
+                .encode(Encoders.DECIMAL())
+                .write(dataSink);
+
+        Assertions.assertEquals(Collections.singletonList(42), data);
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor(staticName = "of")
+    public static class TestBean {
+        int value;
+        String reference;
+    }
+
+    @Test
+    void testSqlMerge() {
+
+        // given
+        List<TestBean> data = new LinkedList<>();
+
+        DataSource<Integer> dataSource1 = () -> sparkSession.createDataset(Arrays.asList(1, 2, 3, 4, 5, 6), Encoders.INT());
+        DataSource<TestBean> dataSource2 = () -> sparkSession.createDataset(Arrays.asList(TestBean.of(1, "one"), TestBean.of(6, "six")), Encoders.bean(TestBean.class));
+
+        DataSink<TestBean> dataSink = d -> data.addAll(d.collectAsList());
+
+        DataBiTransformation<Integer, TestBean, TestBean> tx = Transformation
+                .<Integer, TestBean>sqlMerge("s1", "s2", "select * from (select b.value+1 as value, b.reference as reference from s1 as a join s2 as b on a.value = b.value) where value > 2")
+                .andThenEncode(Encoders.bean(TestBean.class));
+
+        // when
+        DataPipe.mergeAll(DataPipe.read(dataSource1), DataPipe.read(dataSource2), tx).write(dataSink);
+
+        // then
+        Assertions.assertEquals(Collections.singletonList(TestBean.of(7, "six")), data);
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
                 <version>${spark.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.scala-lang.modules</groupId>
+                <artifactId>scala-java8-compat_${scala.version}</artifactId>
+                <version>0.9.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
spark logical plan get replanned so that it does not require a sql statement to be declared in the catalog; this fixes #7 